### PR TITLE
fix a like-bug

### DIFF
--- a/src/main/java/com/porco/bert/chinese/serv/Preprocessor.java
+++ b/src/main/java/com/porco/bert/chinese/serv/Preprocessor.java
@@ -124,7 +124,7 @@ public class Preprocessor {
             String question = questions[i];
             String answer = answers[i];
             int t = process(true, 0 , maxLength, question, inputIds, inputMask, segmentIds);
-            process(true, t , i, answer, inputIds, inputMask, segmentIds);
+            process(true, t , maxLength, answer, inputIds, inputMask, segmentIds);
         }
 
         return new Input(inputIds, inputMask, segmentIds, shape);


### PR DESCRIPTION
thanks for your work about processor
issue:
orgin code run in q&a,get this:
`Exception in thread "main" java.lang.IllegalArgumentException: buffer with 70 elements is not compatible with a Tensor with shape [2, 128]
	at org.tensorflow.Tensor.incompatibleBuffer(Tensor.java:583)
	at org.tensorflow.Tensor.allocateForBuffer(Tensor.java:308)
	at org.tensorflow.Tensor.create(Tensor.java:168)
	at com.Input.tensor(Input.java:40)
	at com.Input.<init>(Input.java:28)
	at com.Preprocessor.preprocess(Preprocessor.java:98)
	at com.Model.predict(Model.java:101)
	at com.Model.predictLabel(Model.java:119)
	at com.Main.main(Main.java:12)

`
change i to maxLength,code will run success